### PR TITLE
refactor: agile chain handling

### DIFF
--- a/scripts/cmd-close.sh
+++ b/scripts/cmd-close.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 #Copyright (C) [2014] [Kamen Medarski]
 #This program is free software; you can redistribute it and/or modify
 #it under the terms of the GNU General Public License as published by
@@ -8,39 +9,64 @@
 #MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 #GNU General Public License for more details.
 
-n='nft'
-
-#DRY commands
-alias nalc='$n -a list chain inet fw4'
-alias ndr='$n delete rule inet fw4'
-
-
+# --- Config ---
+NFT="nft"
 DEFAULTCHAIN="input_fwknop"
 
-handle() {
-    nalc "$DEFAULTCHAIN" | grep "$1" | grep "$2" | grep "$3" | cut -d'#' -f2 | cut -d' ' -f3 | xargs
+# --- Helpers ---
+
+nft_list()   { $NFT -a list chain inet fw4 "$1"; }
+nft_delete() { $NFT delete rule inet fw4 "$@"; }
+
+log() { echo "$*" >&2; }
+
+# --- Core ---
+
+get_handles() {
+    local ip="$1" port="$2" proto="$3"
+    nft_list "$DEFAULTCHAIN" \
+        | grep "$ip" | grep "$port" | grep "$proto" \
+        | cut -d'#' -f2 | awk '{print $2}'
 }
-case $1 in
-    [0-9]*.[0-9]*.[0-9]*.[0-9]*) IP=$1;;
-    *) echo "Invalid IP address $1";;
-esac
 
-case $2 in
-    [0-9]*) PORT=$2;;
-    *) echo "Invalid port $2";;
-esac
+delete_rules() {
+    local ip="$1" port="$2" proto="$3"
+    local found=0
 
-case $3 in
-  17) PROTO=udp;;
-  *) PROTO=tcp;;
-esac
+    for handle in $(get_handles "$ip" "$port" "$proto"); do
+        log "Deleting handle $handle ($ip $proto $port)"
+        nft_delete "$DEFAULTCHAIN" handle "$handle"
+        found=1
+    done
 
-hand="$(handle "$IP" "$PORT" "$PROTO")"
-set -- "$hand"
-for i in $@; do
-    if [ "x$i" != "x" ]; then 
-        ndr "$DEFAULTCHAIN" handle "$i"
-    else
-        echo "Rule with params: ip::$IP port::$PORT proto::$PROTO Not found"
-    fi
-done
+    [ "$found" -eq 0 ] && \
+        log "Rule not found: ip=$ip port=$port proto=$proto"
+}
+
+# --- Argument parsing ---
+
+parse_args() {
+    case "$1" in
+        [0-9]*.[0-9]*.[0-9]*.[0-9]*) IP="$1" ;;
+        *) log "Invalid IP: $1"; exit 1 ;;
+    esac
+
+    case "$2" in
+        [0-9]*) PORT="$2" ;;
+        *) log "Invalid port: $2"; exit 1 ;;
+    esac
+
+    case "$3" in
+        17) PROTO="udp" ;;
+        *)  PROTO="tcp" ;;
+    esac
+}
+
+# --- Main ---
+
+main() {
+    parse_args "$@"
+    delete_rules "$IP" "$PORT" "$PROTO"
+}
+
+main "$@"

--- a/scripts/cmd-open.sh
+++ b/scripts/cmd-open.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 #Copyright (C) [2014] [Kamen Medarski]
 #This program is free software; you can redistribute it and/or modify
 #it under the terms of the GNU General Public License as published by
@@ -8,64 +9,119 @@
 #MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 #GNU General Public License for more details.
 
-n='nft'
-
-#DRY commands
-alias nlcs='$n list chains'
-alias nalc='$n -a list chain inet fw4'
-alias ncc='$n create chain inet fw4'
-alias nlc='$n list chain inet fw4'
-alias nir='$n insert rule inet fw4'
-
-WANCHAIN="input_wan"
-WANFINALRULE="drop_from_wan"
+# --- Config ---
+NFT="nft"
 DEFAULTCHAIN="input_fwknop"
 
-create_unique_rule() {
- if ! ( nalc "$DEFAULTCHAIN" | grep "$1" | grep "$2" | grep "$3" > /dev/null); then
-    nir "$DEFAULTCHAIN" ip saddr "$1" "$2" dport "$3" accept
- fi
+# --- Helpers ---
+
+nft_list()   { $NFT -a  list chain inet fw4 "$1"; }
+nft_listj()  { $NFT -ja list chain inet fw4 "$1"; }
+nft_insert() { $NFT insert rule inet fw4 "$@"; }
+
+log() { echo "$*" >&2; }
+
+# --- Core functions ---
+
+get_iface() {
+    ip -j a | jq -r --arg v "$1" \
+        '.[] | select(any(.addr_info[]; .local == $v)) | .ifname'
 }
 
-ensure_return() {
-  if ! nalc "$DEFAULTCHAIN" | grep "return" > /dev/null; then
-    nir "$DEFAULTCHAIN" return
-  fi
+get_chain() {
+    nft_listj "input" | jq -r --arg v "$1" '
+        .nftables[]
+        | select(
+            .rule.expr? as $expr
+            | $expr and (any($expr[]; .match?["right"]? == $v))
+          )
+        | .rule.expr[1].jump.target? // empty
+    '
 }
 
-create_fwknop_chain() {
-  if ! nlcs | grep "$DEFAULTCHAIN" > /dev/null; then
-  ncc "$DEFAULTCHAIN" > /dev/null
-  fi
+get_first_rule_handle() {
+    nft_listj "$1" | jq -r \
+        '[.nftables[] | select(.rule)] | first | .rule.handle // empty'
 }
 
-case $1 in
-    [0-9]*.[0-9]*.[0-9]*.[0-9]*) IP=$1;;
-    *) echo "Invalid IP address $1";;
-esac
+chain_exists() {
+    $NFT list chains | grep -q "$1"
+}
 
-case $2 in
-    [0-9]*) PORT=$2;;
-    *) echo "Invalid port $2";;
-esac
+chain_has_rule() {
+    nft_list "$1" | grep -q "$2"
+}
 
-case $3 in
-  17) PROTO=udp;;
-  *) PROTO=tcp
-esac
+# Create fwknop chain with a return rule if not exists
+ensure_chain() {
+    if ! chain_exists "$DEFAULTCHAIN"; then
+        log "Creating chain: $DEFAULTCHAIN"
+        $NFT create chain inet fw4 "$DEFAULTCHAIN"
+    fi
+    if ! chain_has_rule "$DEFAULTCHAIN" "return"; then
+        log "Adding return rule to $DEFAULTCHAIN"
+        nft_insert "$DEFAULTCHAIN" return
+    fi
+}
 
-# Handle missing chain. New chain will be created with a simple return statement.
-# Additional rules should be inserted 
+# Insert jump to fwknop chain before first rule of target chain
+ensure_jump() {
+    local ch="$1"
+    if ! chain_has_rule "$ch" "$DEFAULTCHAIN"; then
+        local h
+        h=$(get_first_rule_handle "$ch")
+        log "Inserting jump to $DEFAULTCHAIN in chain $ch before handle $h"
+        nft_insert "$ch" handle "$h" jump "$DEFAULTCHAIN"
+    fi
+}
 
-create_fwknop_chain
-ensure_return
+# Add accept rule if not already present
+ensure_accept_rule() {
+    local ip="$1" proto="$2" port="$3"
+    if ! chain_has_rule "$DEFAULTCHAIN" "$ip" | grep -q "$proto" | grep -q "$port"; then
+        log "Adding rule: $ip $proto $port"
+        nft_insert "$DEFAULTCHAIN" ip saddr "$ip" "$proto" dport "$port" accept
+    fi
+}
 
+# --- Argument parsing ---
 
-# Handle redirect and processing to fwknop chain 
-if ! nlc "$WANCHAIN" | grep "$DEFAULTCHAIN" > /dev/null ; then
-  pos=$(nalc "$WANCHAIN" | grep "$WANFINALRULE" | cut -d'#' -f2 | cut -d' ' -f3)
-  nir "$WANCHAIN" position "$pos" jump "$DEFAULTCHAIN"
-  create_unique_rule "$IP" "$PROTO" "$PORT"
-else
-  create_unique_rule "$IP" "$PROTO" "$PORT"
-fi
+parse_args() {
+    case "$1" in
+        [0-9]*.[0-9]*.[0-9]*.[0-9]*) IP="$1" ;;
+        *) log "Invalid IP: $1"; exit 1 ;;
+    esac
+
+    case "$2" in
+        [0-9]*) PORT="$2" ;;
+        *) log "Invalid port: $2"; exit 1 ;;
+    esac
+
+    case "$3" in
+        17) PROTO="udp" ;;
+        *)  PROTO="tcp" ;;
+    esac
+
+    case "$4" in
+        *.*.*.*:*.*.*.*) SRC_IP="${4%:*}" ;;
+        *) log "Invalid src:dst pair: $4"; exit 1 ;;
+    esac
+}
+
+# --- Main ---
+
+main() {
+    parse_args "$@"
+
+    local iface ch
+    iface=$(get_iface "$SRC_IP")
+    ch=$(get_chain "$iface")
+
+    log "Interface: $iface | Chain: $ch | IP: $IP | Proto: $PROTO | Port: $PORT"
+
+    ensure_chain
+    ensure_jump "$ch"
+    ensure_accept_rule "$IP" "$PROTO" "$PORT"
+}
+
+main "$@"


### PR DESCRIPTION
## Overview
Both  cmd-open.sh  and  cmd-close.sh  have been refactored for readability, safety, and maintainability. 

## Potential Breaking changes:
- position  replaced with  handle
Previous version inserts the jump before  drop_from_wan  (last rule) — meaning it inserts at a specific position by rule number. The refactored version inserts before the first rule by handle. This is a behavioral change if your chain has multiple rules before  drop_from_wan .
- Previous version always assumed a fixed  WANCHAIN="input_wan"  and  WANFINALRULE="drop_from_wan" .
Refactored adds functions to dynamically resolves the interface and chain from the  $4  ( src:dst ) argument. 
- Forth argument should be providev from fwknopd instance where the client stanza defines a SPA_SERVER in the format SPA_SERVER_ADDRESS:CLIENT_ADDRESS
- Client address is usually provided with -a parameter
 
### What Changed

1. Logic wrapped in  main() 
All execution logic is inside  main "$@" . Makes the script sourceable for testing without side effects.
2. Previous version uses  alias  which was replaced with plain functions — functionally identical but actually reliable.
3. Merged two functions into one. Same behavior, fewer moving parts.
4. Handling of empty args now triggers immediate exit of the script. 
5. Added support for $4 parameter with type checks

## Dependencies
The new version is now relaying on few tools that should be installed on the system as well.
- jq
- awk / qawk
- ip (iproute2)

